### PR TITLE
fixed movability of receiver

### DIFF
--- a/include/cr/receiver.hpp
+++ b/include/cr/receiver.hpp
@@ -25,7 +25,8 @@ namespace cr
         receiver(std::shared_ptr<queue<T>>);
 
       public:
-        receiver(receiver &&) noexcept;
+        receiver(receiver &&) noexcept = default;
+        receiver &operator=(receiver &&) noexcept = default;
 
       public:
         receiver(const receiver &)            = delete;

--- a/include/cr/receiver.inl
+++ b/include/cr/receiver.inl
@@ -11,12 +11,6 @@ namespace cr
     }
 
     template <typename T>
-    receiver<T>::receiver(receiver &&other) noexcept : m_queue(std::move(other.m_queue))
-    {
-        other.m_queue = nullptr;
-    }
-
-    template <typename T>
     receiver<T>::~receiver()
     {
         if (!m_queue)


### PR DESCRIPTION
Add missing move assignment operator to `receiver` class.

Further the move constructor could be defaulted as well, right?